### PR TITLE
Update README: fix 'maktabkhooneh' spelling typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # machine_learning_with_python_jadi
 
-Course on Maktabkhoone: https://maktabkhooneh.org/course/%DB%8C%D8%A7%D8%AF%DA%AF%DB%8C%D8%B1%DB%8C-%D9%85%D8%A7%D8%B4%DB%8C%D9%86-%D9%BE%D8%A7%DB%8C%D8%AA%D9%88%D9%86-mk1318/
+Course on Maktabkhooneh: https://maktabkhooneh.org/course/%DB%8C%D8%A7%D8%AF%DA%AF%DB%8C%D8%B1%DB%8C-%D9%85%D8%A7%D8%B4%DB%8C%D9%86-%D9%BE%D8%A7%DB%8C%D8%AA%D9%88%D9%86-mk1318/
 
 My blog: http://jadi.net/2021/10/machine-learning-with-python-jadi/
 


### PR DESCRIPTION
The word “maktabkhooneh” was previously misspelled as “maktabkhoone” in the [README.md](https://github.com/jadijadi/machine_learning_with_python_jadi/blob/main/README.md) file.